### PR TITLE
Put the map pin at the correct conference location

### DIFF
--- a/layouts/partials/venue.html
+++ b/layouts/partials/venue.html
@@ -11,7 +11,7 @@
 				<!-- <div class="gm-map to-animate"> -->
 
 					<div id="map" class="to-animate fadeInUp animated" style="position: relative; overflow: hidden;">
-						<iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3988.817474656375!2d103.85853771534708!3d1.2833753990639525!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x31da19042950679d%3A0x7e9eb96cc0e8d6f2!2sMarina+Bay+Sands!5e0!3m2!1sen!2s!4v1523357353823" width="100%" height="450" frameborder="0" style="border:0" allowfullscreen></iframe>
+						<iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d1994.4094815464418!2d103.85754175814219!3d1.2824206997661616!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x31da1905a913542d%3A0x81a3ad206e972c35!2sMarina+Bay+Sands+Expo+and+Convention+Centre!5e0!3m2!1sen!2ssg!4v1525270488254" width="100%" height="450" frameborder="0" style="border:0" allowfullscreen></iframe>
 					   </div>
 			</div>
 		</div>


### PR DESCRIPTION
Its currently pointing at Marina Bay Sands, "Posh hotel with an infinity
pool & a spa", per GMaps, and that might be confusing.

Lets put the pin on the actual location - the MBS Expo & Convention
Centre.